### PR TITLE
Add random dog image on intermediate page

### DIFF
--- a/intermediate.html
+++ b/intermediate.html
@@ -7,13 +7,19 @@
   body { font-family: system-ui; text-align: center; margin-top: 10vh; }
   button { padding: .6em 1.2em; font-size: 1.1em; }
   #timer { font-size: 3rem; margin: 1rem 0; }
+  #dog {
+    max-width: 300px;
+    display: none;
+    margin: 1rem auto;
+  }
 </style>
 </head>
 <body>
   <h1>Hold on ⚠️</h1>
   <p>You were heading to <b id="site"></b></p>
   <p id="timer">10</p>
+  <img id="dog" alt="Random dog" />
   <button id="go">Continue now</button>
-<script src="intermediate.js"></script>
+  <script src="intermediate.js"></script>
 </body>
 </html>

--- a/intermediate.js
+++ b/intermediate.js
@@ -2,6 +2,20 @@ const params = new URLSearchParams(location.search);
 const url    = params.get('url') || '';
 document.getElementById('site').textContent = (new URL(url)).hostname;
 
+const img = document.getElementById('dog');
+const controller = new AbortController();
+const timeout = setTimeout(() => controller.abort(), 3000);
+fetch('https://dog.ceo/api/breeds/image/random', { signal: controller.signal })
+  .then(r => r.ok ? r.json() : Promise.reject())
+  .then(d => {
+    clearTimeout(timeout);
+    if (d && d.message) {
+      img.src = d.message;
+      img.style.display = 'block';
+    }
+  })
+  .catch(() => {});
+
 let remaining = 10;
 const counter = document.getElementById('timer');
 const tick = setInterval(() => {


### PR DESCRIPTION
## Summary
- fetch and display a random dog image on the intermediate page
- default to original view if the request fails or times out

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68486f19f72083238749dec4d6da7bd7