### PR TITLE
Add configurable delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ It's a chrome extension built to made you stop jumping on to the addictive websi
 * Pull the repository locally.
 * Go to chrome://extensions → Developer Mode → “Load unpacked” → select focus-guard.
 * Click the toolbar icon to enable/disable.
-* Open the Options page to add or remove sites.
+* Open the Options page to add or remove sites and adjust the delay.
 
 That’s it. distraction buffer activated!
 
 ## The Intermediate Page
 
 <img width="383" alt="Intermediate Page" src="https://github.com/user-attachments/assets/2f9e060a-3ed0-4596-8473-e2c34b4a7486" />
+
+You can change how long this screen is shown from the Options page.

--- a/intermediate.js
+++ b/intermediate.js
@@ -2,6 +2,8 @@ const params = new URLSearchParams(location.search);
 const url    = params.get('url') || '';
 document.getElementById('site').textContent = (new URL(url)).hostname;
 
+const DELAY_KEY = 'delay';
+
 const img = document.getElementById('dog');
 const controller = new AbortController();
 const timeout = setTimeout(() => controller.abort(), 3000);
@@ -18,14 +20,20 @@ fetch('https://dog.ceo/api/breeds/image/random', { signal: controller.signal })
 
 let remaining = 10;
 const counter = document.getElementById('timer');
-const tick = setInterval(() => {
-  remaining -= 1;
+
+chrome.storage.sync.get({ [DELAY_KEY]: 10 }, d => {
+  remaining = parseInt(d[DELAY_KEY], 10) || 0;
   counter.textContent = remaining;
-  if (remaining === 0) {
-    clearInterval(tick);
-    location.href = url;
-  }
-}, 1000);
+
+  const tick = setInterval(() => {
+    remaining -= 1;
+    counter.textContent = remaining;
+    if (remaining === 0) {
+      clearInterval(tick);
+      location.href = url;
+    }
+  }, 1000);
+});
 
 document.getElementById('go').addEventListener('click', () => {
   location.href = url;

--- a/options.html
+++ b/options.html
@@ -11,8 +11,14 @@
 <body>
   <h2>Distracting sites (one per line)</h2>
   <textarea id="sites"></textarea>
+  <p>
+    <label>
+      Delay (seconds):
+      <input id="delay" type="number" min="0" step="1" />
+    </label>
+  </p>
   <button id="save">Save</button>
   <p id="status"></p>
-<script src="options.js"></script>
+  <script src="options.js"></script>
 </body>
 </html>

--- a/options.js
+++ b/options.js
@@ -1,10 +1,13 @@
 const SITES_KEY = 'sites';
-const box  = document.getElementById('sites');
-const save = document.getElementById('save');
-const stat = document.getElementById('status');
+const DELAY_KEY = 'delay';
+const box   = document.getElementById('sites');
+const delay = document.getElementById('delay');
+const save  = document.getElementById('save');
+const stat  = document.getElementById('status');
 
-chrome.storage.sync.get({ [SITES_KEY]: ['twitter.com','facebook.com'] }, (d) => {
+chrome.storage.sync.get({ [SITES_KEY]: ['twitter.com','facebook.com'], [DELAY_KEY]: 10 }, (d) => {
   box.value = d[SITES_KEY].join('\n');
+  delay.value = d[DELAY_KEY];
 });
 
 save.onclick = () => {
@@ -13,7 +16,8 @@ save.onclick = () => {
     .map(s => s.trim())
     .filter(Boolean)
     .map(s => s.toLowerCase());
-  chrome.storage.sync.set({ [SITES_KEY]: list }, () => {
+  const secs = Math.max(0, parseInt(delay.value, 10) || 0);
+  chrome.storage.sync.set({ [SITES_KEY]: list, [DELAY_KEY]: secs }, () => {
     stat.textContent = 'Saved ✔︎';
     setTimeout(() => stat.textContent = '', 1500);
   });


### PR DESCRIPTION
## Summary
- allow configuring delay before redirect
- show delay option on the options page
- document the new setting

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68489aefde608323a0ddd222cb4216d2