### PR TITLE
Add optional wait enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ It's a chrome extension built to make you stop jumping on to the addictive websi
 * Go to chrome://extensions → Developer Mode → “Load unpacked” → select focus-guard.
 * Click the toolbar icon to enable/disable.
 * Open the Options page to add or remove sites and adjust the delay.
+* Optionally disable the "Continue now" button until the countdown ends.
 
 That’s it. distraction buffer activated!
 

--- a/intermediate.js
+++ b/intermediate.js
@@ -3,6 +3,7 @@ const url    = params.get('url') || '';
 document.getElementById('site').textContent = (new URL(url)).hostname;
 
 const DELAY_KEY = 'delay';
+const WAIT_KEY  = 'disableContinue';
 
 const img = document.getElementById('dog');
 const controller = new AbortController();
@@ -20,16 +21,20 @@ fetch('https://dog.ceo/api/breeds/image/random', { signal: controller.signal })
 
 let remaining = 10;
 const counter = document.getElementById('timer');
+const goButton = document.getElementById('go');
 
-chrome.storage.sync.get({ [DELAY_KEY]: 10 }, d => {
+chrome.storage.sync.get({ [DELAY_KEY]: 10, [WAIT_KEY]: false }, d => {
   remaining = parseInt(d[DELAY_KEY], 10) || 0;
   counter.textContent = remaining;
+  const waitUntilEnd = d[WAIT_KEY];
+  if (waitUntilEnd) goButton.disabled = true;
 
   const tick = setInterval(() => {
     remaining -= 1;
     counter.textContent = remaining;
     if (remaining === 0) {
       clearInterval(tick);
+      goButton.disabled = false;
       location.href = url;
     }
   }, 1000);

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Focus Guard",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Shows a pause screen before opening distracting sites.",
   "permissions": [
     "storage",

--- a/options.html
+++ b/options.html
@@ -17,6 +17,12 @@
       <input id="delay" type="number" min="0" step="1" />
     </label>
   </p>
+  <p>
+    <label>
+      <input id="disableContinue" type="checkbox" />
+      Disable "Continue now" button until timer ends
+    </label>
+  </p>
   <button id="save">Save</button>
   <p id="status"></p>
   <script src="options.js"></script>

--- a/options.js
+++ b/options.js
@@ -1,13 +1,16 @@
 const SITES_KEY = 'sites';
 const DELAY_KEY = 'delay';
+const WAIT_KEY  = 'disableContinue';
 const box   = document.getElementById('sites');
 const delay = document.getElementById('delay');
+const wait  = document.getElementById('disableContinue');
 const save  = document.getElementById('save');
 const stat  = document.getElementById('status');
 
-chrome.storage.sync.get({ [SITES_KEY]: ['twitter.com','facebook.com'], [DELAY_KEY]: 10 }, (d) => {
+chrome.storage.sync.get({ [SITES_KEY]: ['twitter.com','facebook.com'], [DELAY_KEY]: 10, [WAIT_KEY]: false }, (d) => {
   box.value = d[SITES_KEY].join('\n');
   delay.value = d[DELAY_KEY];
+  wait.checked = d[WAIT_KEY];
 });
 
 save.onclick = () => {
@@ -17,7 +20,7 @@ save.onclick = () => {
     .filter(Boolean)
     .map(s => s.toLowerCase());
   const secs = Math.max(0, parseInt(delay.value, 10) || 0);
-  chrome.storage.sync.set({ [SITES_KEY]: list, [DELAY_KEY]: secs }, () => {
+  chrome.storage.sync.set({ [SITES_KEY]: list, [DELAY_KEY]: secs, [WAIT_KEY]: wait.checked }, () => {
     stat.textContent = 'Saved ✔︎';
     setTimeout(() => stat.textContent = '', 1500);
   });


### PR DESCRIPTION
## Summary
- add configurable `disableContinue` option
- disable 'Continue now' button until timer ends when enabled
- document the new option in the README
- bump extension version to 1.2.0

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f606739f483239bb392f3ae8cbda9